### PR TITLE
add default timeout

### DIFF
--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -126,6 +126,7 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
 
   _.defaults(api, {
     method: 'GET',
+    timeout: 15000, // 15 seconds default
     url: url.format(urlOpts),
     headers: {}
   });


### PR DESCRIPTION
In some cases the frontend app using rendr's data adapter will hang because of improper timeout handling. Set a default timeout to avoid these issues. 15 seconds was chosen as a good value empirically, probably could be a lot less.
